### PR TITLE
Add plugin discovery

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
   rev: v0.3.5
   hooks:
   - id: ruff
+    args: [--fix]
   - id: ruff-format
 
 - repo: https://github.com/pre-commit/mirrors-mypy

--- a/src/niftyone/__init__.py
+++ b/src/niftyone/__init__.py
@@ -1,5 +1,7 @@
 """Large-scale neuroimaging visualization using FiftyOne."""
 
+# Import all plugins. In particular this should register user's custom generators
+from . import plugins
 from ._version import __version__, __version_tuple__
 
 # Register existing views

--- a/src/niftyone/plugins.py
+++ b/src/niftyone/plugins.py
@@ -1,0 +1,13 @@
+"""NiftyOne plugin discovery based on 'niftyone_{plugin_name}' naming convention."""
+
+import importlib
+import pkgutil
+
+PLUGIN_PREFIX = "niftyone_"
+
+# https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-naming-convention
+PLUGINS = {
+    name: importlib.import_module(name)
+    for finder, name, ispkg in pkgutil.iter_modules()
+    if name.startswith(PLUGIN_PREFIX)
+}


### PR DESCRIPTION
We need some way to discover user defined figures outside of the main niftyone namespace. This adds a very basic plugin discovery based on the naming convention `niftyone_{plugin_name}`. See the [python packaging guide](https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/).