### PR TITLE
Fix docs path for generating documentation

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,7 +29,7 @@ jobs:
         pip install -e .\[doc\]
     - name: Build docs
       run: |
-        python doc/make.py
+        python docs/make.py
     # Set up Rust for mdbook
     - name: Install cargo
       uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Quick fix, renaming `doc` to `docs` to reflect actual path of `make.py`.